### PR TITLE
リポジトリのラベルが30個以上ある場合にエラーが発生する問題の修正 (暫定対応)

### DIFF
--- a/src/api/getLabels.ts
+++ b/src/api/getLabels.ts
@@ -5,7 +5,8 @@ export const getLabels = async ({
   client,
   repo,
 }: ApiProps): Promise<Labels> => {
-  const labels = await client.issues.listLabelsForRepo({ ...repo });
+  // TODO: ラベルが100件以上ある場合にページングに対応させる必要がある
+  const labels = await client.issues.listLabelsForRepo({ per_page: 100, ...repo });
   return labels.data.map((label) => ({
     name: label.name,
     description: label.description,


### PR DESCRIPTION
- すでに存在するラベルを作ろうとして github の API  でエラーになっていた問題を修正
    - リポジトリのラベルを取得する処理で、上限が30個までしか取得できないようになっていた
    - `per_page` の最大値 100 を指定することで暫定的に対応する
        - 根本対応のためにはページングに対応させる必要があるが、今起きてる問題の解決のために暫定対応